### PR TITLE
Update absl-py to version 0.15.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "absl-py" %}
-{% set version = "0.13.0" %}
+{% set version = "0.15.0" %}
 {% set file_ext = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash_value = "6953272383486044699fd0e9f00aad167a27e08ce19aae66c6c4b10e7e767793" %}
+{% set hash_value = "72d782fbeafba66ba3e525d46bccac949b9a174dbf66233e50ece09ee688dc81" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ source:
 
 build:
   number: 0
+  # the package absl is not available in s390x
+  skip: True  # [py<36 or s390x]
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 


### PR DESCRIPTION

  absl-py 0.15.0
1. check the upstream
    https://github.com/abseil/abseil-py/tree/pypi-v0.15.0
    
2. check the pinnings
    https://github.com/abseil/abseil-py/blob/pypi-v0.15.0/setup.py
    

3. check the changelogs
    There were no change logs so the code base was explored using the release information
    https://github.com/abseil/abseil-py/compare/pypi-v0.15.0...v1.0.0

4. additional research
    http://github.com/conda-forge/absl-py-feedstock/issues

    No issues at the time of the review

5. verify dev_url
    https://github.com/abseil/abseil-py

6. verify doc_url
    https://abseil.io/docs/

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `absl-py` package version `0.15.0` the folowing
command was used:
`conda build absl-py-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `absl-py` to version `0.15.0`
