### PR TITLE
Update to v1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,15 @@ source:
 
 build:
   number: 0
-  skip: True # [py<36]
+  # The package absl is not available in s390x.
+  skip: True  # [py<36 or s390x]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:
     - python
     - pip
+    - wheel
     - setuptools
   run:
     - python
@@ -30,6 +32,10 @@ test:
     - absl.flags
     - absl.logging
     - absl.testing
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://abseil.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
   home: https://abseil.io/
   license: Apache-2.0
   license_family: Apache
-  llicense_file: LICENSE
+  license_file: LICENSE
   summary: |
     This repository is a collection of Python library code for building Python applications. 
     The code is collected from Google's own Python code base,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,35 +1,28 @@
 {% set name = "absl-py" %}
-{% set version = "0.15.0" %}
-{% set file_ext = "tar.gz" %}
+{% set version = "1.3.0" %}
 {% set hash_type = "sha256" %}
-{% set hash_value = "72d782fbeafba66ba3e525d46bccac949b9a174dbf66233e50ece09ee688dc81" %}
+{% set hash_value = "463c38a08d2e4cef6c498b76ba5bd4858e4c6ef51da1a5a1f27139a022e20248" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ file_ext }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   {{ hash_type }}: {{ hash_value }}
 
 build:
   number: 0
-  # the package absl is not available in s390x
-  skip: True  # [py<36 or s390x]
-  noarch: python
+  skip: True # [py<36]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:
     - python
     - pip
-    - wheel
     - setuptools
-    - six
   run:
     - python
-    - six
 
 test:
   imports:
@@ -37,18 +30,17 @@ test:
     - absl.flags
     - absl.logging
     - absl.testing
-  requires:
-    - pip
-  commands:
-    - pip check
 
 about:
   home: https://abseil.io/
   license: Apache 2.0
   license_family: Apache
   license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
-  summary: Abseil Python Common Libraries, see https://github.com/abseil/abseil-py.
-  doc_url: https://abseil.io/docs/
+  summary: |
+    This repository is a collection of Python library code for building Python applications. 
+    The code is collected from Google's own Python code base,
+    and has been extensively tested and used in production.
+  doc_url: https://abseil.io/docs/python/
   dev_url: https://github.com/abseil/abseil-py
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,15 +39,16 @@ test:
 
 about:
   home: https://abseil.io/
-  license: Apache 2.0
+  license: Apache-2.0
   license_family: Apache
-  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  llicense_file: LICENSE
   summary: |
     This repository is a collection of Python library code for building Python applications. 
     The code is collected from Google's own Python code base,
     and has been extensively tested and used in production.
   doc_url: https://abseil.io/docs/python/
   dev_url: https://github.com/abseil/abseil-py
+  doc_source_url: https://github.com/abseil/abseil-py/blob/main/docs/source/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
`v1.3.0` is the latest version, and we need a new-ish version for `tensorflow 2.10`. It's not strictly required but it'd be good to have anyway.

- `py<36` support dropped.
- `six` is no longer required.